### PR TITLE
RN-39: A wikimodel-emptyline is added after each Developer change

### DIFF
--- a/application-releasenotes-ui/src/main/resources/ReleaseNotes/Code/Change/ChangeDisplayerSimple.xml
+++ b/application-releasenotes-ui/src/main/resources/ReleaseNotes/Code/Change/ChangeDisplayerSimple.xml
@@ -52,9 +52,11 @@
   #generateDisplayEditLink($$displayEditLink, $changeDoc)
   === $changeObject.getValue('title')${displayEditLinkMarkup}=== 
   $changeObject.getValue('summary')
+  #if ("$changeObject.getValue('screenshots')" != '')
 
-  #displayScreenshots($changeObject, true, false)
+    #displayScreenshots($changeObject, true, false)
 
+  #end
   #set ($description = $changeObject.getValue('description'))
   #if ("$!description" != '')
     [[More details&gt;&gt;doc:$changeDoc.documentReference]]


### PR DESCRIPTION
- The emptyline was added because we were trying to display screenshots even if the change didn't had any. Most developer changes don't bring screenshots